### PR TITLE
allow railties (=4.0)

### DIFF
--- a/intl-tel-input-rails.gemspec
+++ b/intl-tel-input-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split("\n")
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", "~> 3.1"
+  spec.add_dependency "railties", ">= 3.1"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Hello @ispyropoulos.

I have the following issue:

```
$ bundle
Fetching gem metadata from https://rubygems.org/.........
Fetching additional metadata from https://rubygems.org/..
Resolving dependencies...
Bundler could not find compatible versions for gem "railties":
  In snapshot (Gemfile.lock):
    railties (4.0.10)

  In Gemfile:
    intl-tel-input-rails (~> 3.6.0) ruby depends on
      railties (~> 3.1) ruby

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.

$ bundle update
Updating git://github.com/plataformatec/simple_form.git
Updating git://github.com/carrierwaveuploader/carrierwave.git
Fetching gem metadata from https://rubygems.org/.........
Fetching additional metadata from https://rubygems.org/..
Resolving dependencies...
Bundler could not find compatible versions for gem "railties":
  In Gemfile:
    intl-tel-input-rails (~> 3.6.0) ruby depends on
      railties (~> 3.1) ruby

    rails (= 4.0.10) ruby depends on
      railties (4.0.10)
$
```

According to [this](http://bundler.io/v1.7/gemfile.html), `~> 3.1` is identical to `>= 3.1 and < 3.2`
is there a special need to use only railties 3.1.\* ?

As I use rails 4.0.10, it needs railties 4.0.10.
